### PR TITLE
Removed warning from rs_replace_table function

### DIFF
--- a/R/replace.R
+++ b/R/replace.R
@@ -94,8 +94,6 @@ rs_replace_table = function(
       queryStmt(dbcon, "COMMIT;")
 
       return(TRUE)
-  }, warning = function(w) {
-      print(w)
   }, error = function(e) {
       print(e$message)
       queryStmt(dbcon, 'ROLLBACK;')


### PR DESCRIPTION
Removed the warning from the `tryCatch()` statement in the `rs_replace_table()` function, since it was causing the function to not upload the data. 
