### PR TITLE
Update max varchar from 65536 to 65535

### DIFF
--- a/R/table_definition.R
+++ b/R/table_definition.R
@@ -7,11 +7,11 @@ calculateCharSize <- function(col){
     warning('Empty column found, setting to 1024 length')
   }
 
-  sizes = 2^c(3:16) # From 8 to 65536, max varchar size in redshift
+  sizes = c(2^c(3:15),65535) # From 8 to 65535, max varchar size in redshift
   fsizes = sizes[ifelse(sizes>maxChar, T, F)]
   if(length(fsizes)==0){
-    warning("Character column over maximum size of 65536, set to that value but will fail if not trimmed before uploading!")
-    warning(paste0('Example offending value: ', head(col[nchar(col) > 65536], 1)))
+    warning("Character column over maximum size of 65535, set to that value but will fail if not trimmed before uploading!")
+    warning(paste0('Example offending value: ', head(col[nchar(col) > 65535], 1)))
     return(max(sizes, na.rm=T))
   }else{
     return(min(fsizes, na.rm=T))


### PR DESCRIPTION
Hi, 

This PR is for change max varchar size from 65536 to 65535.
Based on [redshift documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html#r_Character_types-storage-and-ranges)

This will fix #28 

This is my first ever PR in open source.
I'm sorry if there is any mistake I made.
Please help me to fix it.


