### PR TITLE
Adding session token functionality

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -42,6 +42,7 @@ rs_create_table = function(
     region=Sys.getenv('AWS_DEFAULT_REGION'),
     access_key=Sys.getenv('AWS_ACCESS_KEY_ID'),
     secret_key=Sys.getenv('AWS_SECRET_ACCESS_KEY'),
+    session_token=Sys.getenv('AWS_SESSION_TOKEN'),
     iam_role_arn=Sys.getenv('AWS_IAM_ROLE_ARN'),
     wlm_slots=1,
     sortkeys,
@@ -59,6 +60,6 @@ rs_create_table = function(
 
   queryStmt(dbcon, tableSchema)
 
-  return(rs_replace_table(df, dbcon, table_name, split_files, bucket, region, access_key, secret_key, iam_role_arn, wlm_slots, additional_params))
+  return(rs_replace_table(df, dbcon, table_name, split_files, bucket, region, access_key, secret_key, session_token, iam_role_arn, wlm_slots, additional_params))
 
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -70,14 +70,20 @@ s3ToRedshift = function(dbcon, table_name, bucket, prefix, region, access_key, s
     queryStmt(dbcon, sprintf("create temp table %s (like %s)", stageTable, table_name))
 
     print("Copying data from S3 into Redshift")
+    print(region)
+    print(access_key)
+    print(secret_key)
+    print(session)
+    print(iam_role_arn)
+
     copyStr = "copy %s from 's3://%s/%s.' region '%s' csv gzip ignoreheader 1 emptyasnull COMPUPDATE FALSE STATUPDATE FALSE %s %s"
 
     # Use IAM Role if available
-    if (nchar(iam_role_arn) > 0) {
-      credsStr = sprintf("iam_role '%s'", iam_role_arn)
-    } else {
-      credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s'", access_key, secret_key)
-    }
+    # if (nchar(iam_role_arn) > 0) {
+    #   credsStr = sprintf("iam_role '%s'", iam_role_arn)
+    # } else {
+    #   credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s'", access_key, secret_key)
+    # }
     statement = sprintf(copyStr, stageTable, bucket, prefix, region, additional_params, credsStr)
     queryStmt(dbcon,statement)
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -68,20 +68,12 @@ s3ToRedshift = function(dbcon, table_name, bucket, prefix, region, access_key, s
     stageTable=paste0(sample(letters,16),collapse = "")
     # Create temporary table for staging data
     queryStmt(dbcon, sprintf("create temp table %s (like %s)", stageTable, table_name))
-
-    print("Copying data from S3 into Redshift")
-    print(region)
-    print(access_key)
-    print(secret_key)
-    print(session)
-    print(iam_role_arn)
-
     copyStr = "copy %s from 's3://%s/%s.' region '%s' csv gzip ignoreheader 1 emptyasnull COMPUPDATE FALSE STATUPDATE FALSE %s %s"
-
     # Use IAM Role if available
     if (nchar(iam_role_arn) > 0) {
       credsStr = sprintf("iam_role '%s'", iam_role_arn)
     } else {
+      # creds string now includes a token in case it is needed.
       credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s;token=%s'", access_key, secret_key, session)
     }
     print(credsStr)

--- a/R/internal.R
+++ b/R/internal.R
@@ -82,7 +82,7 @@ s3ToRedshift = function(dbcon, table_name, bucket, prefix, region, access_key, s
     if (nchar(iam_role_arn) > 0) {
       credsStr = sprintf("iam_role '%s'", iam_role_arn)
     } else {
-      credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s;aws_session_token=%s'", access_key, secret_key, session)
+      credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s;token=%s'", access_key, secret_key, session)
     }
     print(credsStr)
     statement = sprintf(copyStr, stageTable, bucket, prefix, region, additional_params, credsStr)

--- a/R/internal.R
+++ b/R/internal.R
@@ -79,11 +79,11 @@ s3ToRedshift = function(dbcon, table_name, bucket, prefix, region, access_key, s
     copyStr = "copy %s from 's3://%s/%s.' region '%s' csv gzip ignoreheader 1 emptyasnull COMPUPDATE FALSE STATUPDATE FALSE %s %s"
 
     # Use IAM Role if available
-    # if (nchar(iam_role_arn) > 0) {
-    #   credsStr = sprintf("iam_role '%s'", iam_role_arn)
-    # } else {
-    #   credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s'", access_key, secret_key)
-    # }
+    if (nchar(iam_role_arn) > 0) {
+      credsStr = sprintf("iam_role '%s'", iam_role_arn)
+    } else {
+      credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s'", access_key, secret_key)
+    }
     statement = sprintf(copyStr, stageTable, bucket, prefix, region, additional_params, credsStr)
     queryStmt(dbcon,statement)
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -82,10 +82,11 @@ s3ToRedshift = function(dbcon, table_name, bucket, prefix, region, access_key, s
     if (nchar(iam_role_arn) > 0) {
       credsStr = sprintf("iam_role '%s'", iam_role_arn)
     } else {
-      credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s'", access_key, secret_key)
+      credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s;aws_session_token=%s'", access_key, secret_key, session)
     }
+    print(credsStr)
     statement = sprintf(copyStr, stageTable, bucket, prefix, region, additional_params, credsStr)
-    queryStmt(dbcon,statement)
+    queryStmt(dbcon, statement)
 
     return(stageTable)
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -76,7 +76,6 @@ s3ToRedshift = function(dbcon, table_name, bucket, prefix, region, access_key, s
       # creds string now includes a token in case it is needed.
       credsStr = sprintf("credentials 'aws_access_key_id=%s;aws_secret_access_key=%s;token=%s'", access_key, secret_key, session)
     }
-    print(credsStr)
     statement = sprintf(copyStr, stageTable, bucket, prefix, region, additional_params, credsStr)
     queryStmt(dbcon, statement)
 

--- a/R/upsert.R
+++ b/R/upsert.R
@@ -45,6 +45,7 @@ rs_upsert_table = function(
     region=Sys.getenv('AWS_DEFAULT_REGION'),
     access_key=Sys.getenv('AWS_ACCESS_KEY_ID'),
     secret_key=Sys.getenv('AWS_SECRET_ACCESS_KEY'),
+    session_token=Sys.getenv('AWS_SESSION_TOKEN'),
     iam_role_arn=Sys.getenv('AWS_IAM_ROLE_ARN'),
     wlm_slots=1,
     additional_params=''
@@ -70,14 +71,14 @@ rs_upsert_table = function(
   split_files = pmin(split_files, numRows)
 
   # Upload data to S3
-  prefix = uploadToS3(df, bucket, split_files, access_key, secret_key, region)
+  prefix = uploadToS3(df, bucket, split_files, access_key, secret_key, session_token, region)
 
   if(wlm_slots>1){
     queryStmt(dbcon,paste0("set wlm_query_slot_count to ", wlm_slots));
   }
 
   result = tryCatch({
-    stageTable=s3ToRedshift(dbcon, table_name, bucket, prefix, region, access_key, secret_key, iam_role_arn, additional_params)
+    stageTable=s3ToRedshift(dbcon, table_name, bucket, prefix, region, access_key, secret_key, session_token, iam_role_arn, additional_params)
 
     # Use a single transaction
     queryStmt(dbcon, 'begin')
@@ -113,7 +114,7 @@ rs_upsert_table = function(
       return(FALSE)
   }, finally = {
     print("Deleting temporary files from S3 bucket")
-    deletePrefix(prefix, bucket, split_files, access_key, secret_key, region)
+    deletePrefix(prefix, bucket, split_files, access_key, secret_key, session_token, region)
   })
 
   return (result)

--- a/R/upsert2.R
+++ b/R/upsert2.R
@@ -47,6 +47,7 @@ rs_cols_upsert_table = function(dat,
                                 region = Sys.getenv('AWS_DEFAULT_REGION'),
                                 access_key = Sys.getenv('AWS_ACCESS_KEY_ID'),
                                 secret_key = Sys.getenv('AWS_SECRET_ACCESS_KEY'),
+                                session_token=Sys.getenv('AWS_SESSION_TOKEN'),
                                 iam_role_arn = Sys.getenv('AWS_IAM_ROLE_ARN'),
                                 wlm_slots = 1,
                                 additional_params = '') {
@@ -69,7 +70,7 @@ rs_cols_upsert_table = function(dat,
   split_files = pmin(split_files, numRows)
 
   # Upload data to S3
-  prefix = uploadToS3(dat, bucket, split_files, access_key, secret_key, region)
+  prefix = uploadToS3(dat, bucket, split_files, access_key, secret_key, session_token, region)
 
   if (wlm_slots > 1) {
     queryStmt(dbcon, paste0("set wlm_query_slot_count to ", wlm_slots))
@@ -84,6 +85,7 @@ rs_cols_upsert_table = function(dat,
       region,
       access_key,
       secret_key,
+      session_token,
       iam_role_arn,
       additional_params
     )
@@ -148,7 +150,7 @@ rs_cols_upsert_table = function(dat,
     return(FALSE)
   }, finally = {
     print("Deleting temporary files from S3 bucket")
-    deletePrefix(prefix, bucket, split_files, access_key, secret_key, region)
+    deletePrefix(prefix, bucket, split_files, access_key, secret_key, session_token, region)
   })
 
   return (result)


### PR DESCRIPTION
On EC2s with an IAM role, AWS issues credentials to the device.  Those credentials include a session token that cloudyR know to look for.  This PR includes minor changes to let redshiftTools pass session tokens to the functions in cloudyR that need them.